### PR TITLE
feat: 액세스 토큰 파싱

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2' // jwt 사용
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/week3team2/lectureservice/model/token/TokenInfo.java
+++ b/src/main/java/com/week3team2/lectureservice/model/token/TokenInfo.java
@@ -1,0 +1,33 @@
+package com.week3team2.lectureservice.model.token;
+
+import com.week3team2.lectureservice.model.member.MemberType;
+import io.jsonwebtoken.Claims;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class TokenInfo {
+    private int memberId;
+    private MemberType memberType;
+    private String exp;
+
+    public static TokenInfo create(Claims tokenClaims) {
+        int memberId = (int) tokenClaims.get("memberId");
+        MemberType memberType = getMemberType(tokenClaims.get("memberType").toString());
+        String exp =  tokenClaims.get("exp").toString();
+
+        return new TokenInfo(memberId, memberType, exp);
+    }
+
+    public static MemberType getMemberType(String value) {
+        switch(value) {
+            case "ADMIN": return MemberType.ADMIN;
+            case "TEACHER": return MemberType.TEACHER;
+            case "STUDENT": return MemberType.STUDENT;
+            default: return null;
+        }
+    }
+}

--- a/src/main/java/com/week3team2/lectureservice/utils/JwtManager.java
+++ b/src/main/java/com/week3team2/lectureservice/utils/JwtManager.java
@@ -1,0 +1,24 @@
+package com.week3team2.lectureservice.utils;
+
+import com.week3team2.lectureservice.model.token.TokenInfo;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+
+@Component
+public class JwtManager {
+    @Value("${jwt.secret}")
+    private String secret;
+
+    public TokenInfo getTokenInfo(String accessToken) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        Claims tokenClaims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        TokenInfo tokenInfo = TokenInfo.create(tokenClaims);
+        return tokenInfo;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,11 @@ logging:
       springframework:
         r2dbc: DEBUG
 debug: false
+
+jwt:
+  #BASE64 인코딩 : codestates-bithumb-msa-team-member-spring-boot-webflux-jwt-secret
+  secret: Y29kZXN0YXRlcy1iaXRodW1iLW1zYS10ZWFtLW1lbWJlci1zcHJpbmctYm9vdC13ZWJmbHV4LWp3dC1zZWNyZXQ=
+  accessExpires:  7200000 #2시간 ms
+  refreshExpires:  172800000 #2주 ms
+
+

--- a/src/test/java/com/week3team2/lectureservice/utils/JwtManagerTest.java
+++ b/src/test/java/com/week3team2/lectureservice/utils/JwtManagerTest.java
@@ -1,0 +1,68 @@
+package com.week3team2.lectureservice.utils;
+
+import com.week3team2.lectureservice.model.token.TokenInfo;
+import com.week3team2.lectureservice.model.member.Member;
+import com.week3team2.lectureservice.model.member.MemberType;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.crypto.SecretKey;
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class JwtManagerTest {
+    @Autowired
+    JwtManager jwtManager;
+    @Value("${jwt.secret}")
+    private String secret;
+    @Value("${jwt.refreshExpires}")
+    private String refreshExpiresString;
+
+    String generateTestToken(Member member) {
+        long refreshExpires = Long.parseLong(refreshExpiresString);
+        Date expiration = new Date(System.currentTimeMillis() + refreshExpires);
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+
+        return Jwts.builder()
+                .claim("memberId", member.getMemberId()) // MemberId
+                .claim("memberType", member.getMemberType()) // MemberType
+                .signWith(key, SignatureAlgorithm.HS256) // 해시값
+                .setExpiration(expiration) // 만료시간
+                .compact();
+
+    }
+
+    @Test
+    void getTokenInfo() {
+        Timestamp nowTimestamp = new Timestamp(System.currentTimeMillis());
+
+            Member member1 = new Member(1, "memberName", "memberPassword", MemberType.ADMIN, nowTimestamp,
+            nowTimestamp);
+            String accessToken1 = generateTestToken(member1);
+
+            // 헤더로부터 토큰을 받아서 tokenInfo객체를 생성합니다.
+            TokenInfo tokenInfo = jwtManager.getTokenInfo(accessToken1);
+
+            // tokenInfo는 memberId와 memberType, exp를 제공합니다.
+            assertThat(tokenInfo.getMemberId()).isEqualTo(1);
+            assertThat(tokenInfo.getMemberType()).isEqualTo(MemberType.ADMIN);
+
+            Member member2 = new Member(11, "memberName", "memberPassword", MemberType.TEACHER, nowTimestamp,
+            nowTimestamp);
+            String accessToken2 = generateTestToken(member2);
+            TokenInfo tokenInfo2 = jwtManager.getTokenInfo(accessToken2);
+            assertThat(tokenInfo2.getMemberId()).isEqualTo(11);
+            assertThat(tokenInfo2.getMemberType()).isEqualTo(MemberType.TEACHER);
+
+    }
+
+}


### PR DESCRIPTION
액세스 토큰이 헤더로 전달되었을 때 해당 토큰에서 memberId, memberType을 파싱할 수 있는 기능을 추가합니다. 